### PR TITLE
fix duplicate PROCESS_VM_OPERATION and replace for PROCESS_VM_WRITE

### DIFF
--- a/Process Injection/DLL Injection/injection.c
+++ b/Process Injection/DLL Injection/injection.c
@@ -40,7 +40,7 @@ BOOL DLLInjection(
     INFO("supplied DLL: \"%S\"", DLLPath);
     INFO("trying to get a handle on the process (%ld)...", ProcessId);
     ProcessHandle = OpenProcess(
-            (PROCESS_VM_OPERATION | PROCESS_VM_OPERATION), 
+            (PROCESS_VM_OPERATION | PROCESS_VM_WRITE), 
             FALSE, 
             ProcessId
             );


### PR DESCRIPTION
In the provided code for DLL injection, you've added PROCESS_VM_OPERATION twice in the OpenProcess instruction.

This results in the program not writing any memory to the process we're trying to inject to, and the DLL instructions not executing. 

Provided is the fix