### PR TITLE
Read 2 bytes for SSN

### DIFF
--- a/Direct Syscalls/injection.c
+++ b/Direct Syscalls/injection.c
@@ -32,7 +32,11 @@ VOID GetSyscallNumber(
         return;
     }
 
-    *NtFunctionSSN = ((PBYTE)(NtFunctionAddress + 0x4))[0];
+    // Read the 4th and 5th bytes, as the system call numbers occupy 2 bytes
+    BYTE byte4 = ((PBYTE)NtFunctionAddress)[4];
+    BYTE byte5 = ((PBYTE)NtFunctionAddress)[5];
+    *NtFunctionSSN = (byte5 << 8) | byte4; // Combine to a single DWORD
+    
     INFO("[0x%p] [0x%0.3lx] -> %s", (PVOID)NtFunctionAddress, *NtFunctionSSN, NtFunctionName);
     return;
 

--- a/Indirect Syscalls/injection.c
+++ b/Indirect Syscalls/injection.c
@@ -35,7 +35,11 @@ VOID IndirectPrelude(
         return;
     }
 
-    *NtFunctionSSN = ((PBYTE)(NtFunctionAddress + 0x4))[0];
+    // Read the 4th and 5th bytes, as the system call numbers occupy 2 bytes
+    BYTE byte4 = ((PBYTE)NtFunctionAddress)[4];
+    BYTE byte5 = ((PBYTE)NtFunctionAddress)[5];
+    *NtFunctionSSN = (byte5 << 8) | byte4; // Combine to a single DWORD
+
     *NtFunctionSyscall = NtFunctionAddress + 0x12;
 
     /* making memcmp happy */


### PR DESCRIPTION
Hey,

I noticed your GetSSN function was reading only the first byte (index position 4) for the SSN number - however SSNs are two bytes in length meaning if you were to make a syscall of a SSN larger than 255, you would get a runtime exception as you are calling the wrong function in the Kernel.

Demonstrated as below:

Choosing an NT function at random where SSN > 255:

<img width="1372" alt="table" src="https://github.com/cr-0w/maldev/assets/49762827/b1f8c05f-2f24-4aa0-bea0-b66bac46a5b4">

You can also see it here in x64dbg:

<img width="422" alt="NtSystemDebugControl" src="https://github.com/cr-0w/maldev/assets/49762827/94fbe2c6-ca63-4a5a-aa74-c7df41f663e6">

Original call would resolve this to decimal 205 (0xcd)

<img width="302" alt="before" src="https://github.com/cr-0w/maldev/assets/49762827/597c020e-c345-4ad7-979b-00077074c607">

However, the correct SSN for this on my current Windows build is 461 (0x1cd) - fixing the bug:

<img width="311" alt="after" src="https://github.com/cr-0w/maldev/assets/49762827/f15c7ec3-05db-4ac3-8799-079b24e7da10">

Tested with both direct and indirect syscall projects:

**Direct**

<img width="343" alt="1byte" src="https://github.com/cr-0w/maldev/assets/49762827/a18c9923-2167-4d11-8fb5-757690ef7b62">

**Indirect**

<img width="547" alt="indirect" src="https://github.com/cr-0w/maldev/assets/49762827/f34b39fc-cbd4-431c-8b6a-b8456a3e989f">

Hopefully this makes sense! Happy to answer any other questions or engage further! 